### PR TITLE
correciones: correo y username ya no son unicos

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -17,8 +17,8 @@ datasource db {
 model User {
   idUser      Int      @id @default(autoincrement())  // ID único
   idUserType  Int      @map("idUserType")  // ID del tipo de usuario
-  email       String   @unique
-  username    String   @unique
+  email       String   
+  username    String   
   password    String
   status      Boolean
   createdAt   DateTime @default(now())

--- a/backend/src/services/auth.service.js
+++ b/backend/src/services/auth.service.js
@@ -10,20 +10,33 @@ const SALT_ROUNDS = 10;
 async function registerUser(email, password, username, name, lastName, secondLastName, phone, /*idUserType*/) {
     return await prisma.$transaction(async (tx) => {
 
-        const existingEmail = await tx.user.findUnique({
+        //cambiar findUnique por findFirst
+        // const existingEmail = await tx.user.findUnique({
+        //     where: {
+        //         email: email,
+        //     },
+        // });
+        // if (existingEmail) {
+        //     throw new Error('Email ya existente');
+        // }
+
+        const existingEmail = await tx.user.findFirst({
             where: {
                 email: email,
-            },
+                status: true
+            }
         });
         if (existingEmail) {
-            throw new Error('Email ya existente');
+            throw new Error('Email ya registrado');
         }
 
-        const existingUsername = await tx.user.findUnique({
+        const existingUsername = await tx.user.findFirst({
             where: {
                 username: username,
+                status: true
             },
         });
+
         if (existingUsername) {
             throw new Error('Nombre de usuario ya existente');
         }
@@ -207,29 +220,33 @@ async function updatePassword(userId, oldPassword, newPassword) {
 }
 
 async function updateEmail(userId, email) {
-    // Validate if email already exists
-    const existingUser = await prisma.user.findUnique({
-        where: { email }
-    });
+    try {
+        // Validate if email already exists
+        const existingUser = await prisma.user.findFirst({
+            where: { email, status: true }
+        });
 
-    if (existingUser && existingUser.idUser !== userId) {
-        throw new Error('Este correo electrónico ya está en uso');
-    }
-
-    // Update email
-    const updatedUser = await prisma.user.update({
-        where: { idUser: userId },
-        data: { email },
-        select: {
-            idUser: true,
-            email: true,
-            username: true,
-            status: true,
-            idUserType: true
+        if (existingUser && existingUser.idUser !== userId) {
+            throw new Error('Este correo electrónico ya está en uso');
         }
-    });
 
-    return updatedUser;
+        // Update email
+        const updatedUser = await prisma.user.update({
+            where: { idUser: userId },
+            data: { email },
+            select: {
+                idUser: true,
+                email: true,
+                username: true,
+                status: true,
+                idUserType: true
+            }
+        });
+
+        return updatedUser;
+    } catch (error) {
+        throw error;
+    }
 }
 
 module.exports = {


### PR DESCRIPTION
Cambios en esquema de prima: username y email ya no son únicos. Cambios en auth.servise: 
🔹 Evita errores en la actualización de correo electrónico cuando estos datos ya existen en otro usuario activo.
🔹 Permite la creación de nuevos usuarios siempre y cuando no exista algún otro con el mismo nombre de usuario correo con estado "activo"
🔹 Ahora respeta la integridad de la base de datos
