### PR TITLE
Endpoint para registrar nuevos admistradores añadido

### DIFF
--- a/backend/docs/API.md
+++ b/backend/docs/API.md
@@ -7,142 +7,211 @@
 **POST /api/auth/register**
 
 **Cuerpo de la Petición:**
+
 ```json
 {
-    "username": "usuario123",
-    "email": "usuario@ejemplo.com",
-    "password": "Contraseña123!",
-    "name": "Juan",
-    "lastName": "Pérez",
-    "secondLastName": "García",    // Opcional
-    "phone": "1234567890"
+  "username": "usuario123",
+  "email": "usuario@ejemplo.com",
+  "password": "Contraseña123!",
+  "name": "Juan",
+  "lastName": "Pérez",
+  "secondLastName": "García", // Opcional
+  "phone": "1234567890"
 }
 ```
 
 **Respuesta Exitosa (201):**
+
 ```json
 {
+  "idUser": 1,
+  "email": "usuario@ejemplo.com",
+  "username": "usuario123",
+  "status": true,
+  "idUserType": 2
+}
+```
+
+**Errores Posibles:**
+
+- 400: Email ya existente
+- 400: Nombre de usuario ya existente
+- 400: Errores de validación
+
+### 1.2 Registro de Adminitrador
+
+Permite a los aministradores, registrar nuevos usuarios adminstradores o clientes,
+
+**POST /api/admin/register**
+
+**Headers Requeridos:**
+
+```
+Authorization: Bearer <token>
+```
+
+**Cuerpo de la Petición:**
+
+```json
+{
+  "email": "admin2@example.com",
+  "password": "Contraseña123!",
+  "username": "admin2",
+  "name": "Admin2",
+  "lastName": "Ejemplo",
+  "secondLastName": "Apellido",
+  "phone": "1234567890",
+  "idUserType": 1
+}
+```
+
+**Respuesta Exitosa (201):**
+
+```json
+{
+  "idUser": 1,
+  "email": "usuario@ejemplo.com",
+  "username": "usuario123",
+  "status": true,
+  "idUserType": 1
+}
+```
+
+**Errores Posibles:**
+
+- 400: Email ya existente
+- 400: Nombre de usuario ya existente
+- 400: Errores de validación
+- 403: Acceso denegado.
+
+**Nota:**
+
+- Un **aministrador** puede definir `"idUserType"` :
+  - 1: Para registrar a un nuevo administrador
+  - 2: Para registrar a un nuevo cliente
+
+### 1.3 Inicio de Sesión
+
+**POST /api/auth/login**
+
+**Cuerpo de la Petición:**
+
+```json
+{
+  "email": "usuario@ejemplo.com", // O usar username
+  "username": "usuario123", // O usar email
+  "password": "Contraseña123!"
+}
+```
+
+**Respuesta Exitosa (200):**
+
+```json
+{
+  "message": "Login exitoso",
+  "user": {
     "idUser": 1,
     "email": "usuario@ejemplo.com",
     "username": "usuario123",
     "status": true,
     "idUserType": 1
+  },
+  "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
 }
 ```
 
 **Errores Posibles:**
-- 400: Email ya existente
-- 400: Nombre de usuario ya existente
-- 400: Errores de validación
 
-### 1.2 Inicio de Sesión
-
-**POST /api/auth/login**
-
-**Cuerpo de la Petición:**
-```json
-{
-    "email": "usuario@ejemplo.com",     // O usar username
-    "username": "usuario123",           // O usar email
-    "password": "Contraseña123!"
-}
-```
-
-**Respuesta Exitosa (200):**
-```json
-{
-    "message": "Login exitoso",
-    "user": {
-        "idUser": 1,
-        "email": "usuario@ejemplo.com",
-        "username": "usuario123",
-        "status": true,
-        "idUserType": 1
-    },
-    "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
-}
-```
-
-**Errores Posibles:**
 - 400: Usuario no encontrado
 - 400: Contraseña incorrecta
 
-### 1.3 Perfil de Usuario
+### 1.4 Perfil de Usuario
 
 **GET /api/auth/profile**
 
 **Headers Requeridos:**
+
 ```
 Authorization: Bearer <token>
 ```
 
 **Respuesta Exitosa (200):**
+
 ```json
 {
-    "user": {
-        "userId": 1,
-        "email": "usuario@ejemplo.com",
-        "username": "usuario123",
-        "userType": 1
-    }
+  "user": {
+    "userId": 1,
+    "email": "usuario@ejemplo.com",
+    "username": "usuario123",
+    "userType": 1
+  }
 }
 ```
 
 **Errores Posibles:**
+
 - 401: Token no proporcionado
 - 403: Token inválido
 
-### 1.4 Eliminar Perfil
+### 1.5 Eliminar Perfil
 
 **DELETE /api/auth/profile**
 
 **Headers Requeridos:**
+
 ```
 Authorization: Bearer <token>
 ```
 
 **Respuesta Exitosa (200):**
+
 ```json
 {
-    "message": "Cuenta desactivada exitosamente"
+  "message": "Cuenta desactivada exitosamente"
 }
 ```
 
 **Errores Posibles:**
+
 - 401: Token no proporcionado
 - 403: Token inválido
 
-### 1.5 Actualizar Contraseña
+### 1.6 Actualizar Contraseña
 
 **PUT /api/auth/password**
 
 **Headers Requeridos:**
+
 ```
 Authorization: Bearer <token>
 ```
 
 **Cuerpo de la Petición:**
+
 ```json
 {
-    "oldPassword": "ContraseñaActual123!",
-    "newPassword": "NuevaContraseña123!"
+  "oldPassword": "ContraseñaActual123!",
+  "newPassword": "NuevaContraseña123!"
 }
 ```
 
 **Respuesta Exitosa (200):**
+
 ```json
 {
-    "message": "Contraseña actualizada exitosamente"
+  "message": "Contraseña actualizada exitosamente"
 }
 ```
 
 **Errores Posibles:**
+
 - 400: Contraseña actual incorrecta
 - 400: Nueva contraseña no cumple requisitos
 - 401: Token no proporcionado
 - 403: Token inválido
 
 **Nota de Desarrollo:**
+
 - En ambiente de desarrollo, las contraseñas se almacenan sin encriptar para facilitar testing
 - En producción, se utilizará bcrypt + AES-256 para el manejo seguro de contraseñas
 
@@ -151,33 +220,40 @@ Authorization: Bearer <token>
 ### 2.1 Reglas de Validación
 
 **username:**
+
 - Mínimo 3 caracteres
 - Máximo 12 caracteres
 
 **email:**
+
 - Formato válido de correo electrónico
 
 **password:**
+
 - Mínimo 6 caracteres
 - Al menos 1 mayúscula
 - Al menos 1 minúscula
 - Al menos 1 número
-- Al menos 1 carácter especial (@$!%*?&)
+- Al menos 1 carácter especial (@$!%\*?&)
 
 **phone:**
+
 - Exactamente 10 dígitos
 - Solo números
 
 **name:**
+
 - No puede estar vacío
 - Se convierte automáticamente a mayúsculas
 
 **lastName:**
+
 - No puede estar vacío
 - Solo letras (incluyendo acentos y ñ)
 - Se convierte automáticamente a mayúsculas
 
 **secondLastName:**
+
 - Opcional
 - Solo letras (incluyendo acentos y ñ)
 - Se convierte automáticamente a mayúsculas
@@ -185,27 +261,31 @@ Authorization: Bearer <token>
 ## 3. SEGURIDAD
 
 ### 3.1 Rate Limiting
+
 - Límite: 100 peticiones por IP
 - Ventana de tiempo: 15 minutos
 - Mensaje al exceder límite: "Demasiadas peticiones desde esta IP, por favor intente de nuevo después de 15 minutos"
 
 ### 3.2 JWT (JSON Web Tokens)
+
 - Generado en login exitoso
 - Duración: 24 horas
 - Debe incluirse en header: Authorization: Bearer <token>
 - Contiene: userId, email, username, userType
 
 ## 4. CÓDIGOS DE ESTADO
-| Código | Descripción |
-|--------|-------------|
-| 200 | Operación exitosa |
-| 201 | Recurso creado |
-| 400 | Error en la solicitud |
-| 401 | No autorizado |
-| 403 | Prohibido |
-| 429 | Demasiadas solicitudes |
+
+| Código | Descripción            |
+| ------ | ---------------------- |
+| 200    | Operación exitosa      |
+| 201    | Recurso creado         |
+| 400    | Error en la solicitud  |
+| 401    | No autorizado          |
+| 403    | Prohibido              |
+| 429    | Demasiadas solicitudes |
 
 ## 5. NOTAS TÉCNICAS
+
 - Base de datos: MySQL
 - ORM: Prisma
 - Autenticación: JWT
@@ -213,17 +293,19 @@ Authorization: Bearer <token>
 - Rate Limiting: express-rate-limit
 
 ## 6. VARIABLES DE ENTORNO REQUERIDAS
-| Variable | Descripción |
-|----------|-------------|
+
+| Variable     | Descripción                              |
+| ------------ | ---------------------------------------- |
 | DATABASE_URL | URL de conexión a la base de datos MySQL |
-| JWT_SECRET | Clave secreta para firmar tokens JWT |
+| JWT_SECRET   | Clave secreta para firmar tokens JWT     |
 
 ## 7. CONSIDERACIONES DE DESARROLLO
+
 - Todas las contraseñas deben ser hasheadas antes de almacenarse
 - Los nombres y apellidos se almacenan en mayúsculas
 - El tipo de usuario por defecto es 1 (usuario normal)
 - Se recomienda usar HTTPS en producción
-- Configurar un valor seguro para JWT_SECRET en producción 
+- Configurar un valor seguro para JWT_SECRET en producción
 
 ## 8. ENDPOINTS DE ADMINISTRADOR
 
@@ -234,34 +316,37 @@ Authorization: Bearer <token>
 Lista todos los productos con paginación.
 
 **Headers Requeridos:**
+
 ```
 Authorization: Bearer <token>
 ```
 
 **Parámetros de Query:**
+
 - page: Número de página (default: 1)
 - limit: Productos por página (default: 5)
 
 **Respuesta Exitosa (200):**
+
 ```json
 {
-    "message": "Productos obtenidos correctamente",
-    "data": {
-        "products": [
-            {
-                "idProduct": 1,
-                "name": "Hamburguesa Clásica",
-                "description": "Hamburguesa con carne, lechuga, tomate y queso",
-                "price": 89.99,
-                "status": true,
-                "productType": {
-                    "type": "Comida"
-                }
-            }
-        ],
-        "totalPages": 3,
-        "currentPage": 1
-    }
+  "message": "Productos obtenidos correctamente",
+  "data": {
+    "products": [
+      {
+        "idProduct": 1,
+        "name": "Hamburguesa Clásica",
+        "description": "Hamburguesa con carne, lechuga, tomate y queso",
+        "price": 89.99,
+        "status": true,
+        "productType": {
+          "type": "Comida"
+        }
+      }
+    ],
+    "totalPages": 3,
+    "currentPage": 1
+  }
 }
 ```
 
@@ -275,25 +360,27 @@ Obtiene un producto específico por ID.
 | id | number | ID del producto |
 
 **Respuesta Exitosa (200):**
+
 ```json
 {
-    "message": "Producto obtenido correctamente",
-    "data": {
-        "product": {
-            "idProduct": 1,
-            "name": "Hamburguesa Clásica",
-            "description": "Hamburguesa con carne, lechuga, tomate y queso",
-            "price": 89.99,
-            "status": true,
-            "idProductType": 1,
-            "idUserAdded": 1,
-            "createdAt": "2025-02-20T16:06:12.006Z"
-        }
+  "message": "Producto obtenido correctamente",
+  "data": {
+    "product": {
+      "idProduct": 1,
+      "name": "Hamburguesa Clásica",
+      "description": "Hamburguesa con carne, lechuga, tomate y queso",
+      "price": 89.99,
+      "status": true,
+      "idProductType": 1,
+      "idUserAdded": 1,
+      "createdAt": "2025-02-20T16:06:12.006Z"
     }
+  }
 }
 ```
 
 **Errores Posibles:**
+
 - 400: ID de producto inválido
 - 404: Producto no encontrado
 - 401: Token no proporcionado
@@ -304,19 +391,21 @@ Obtiene un producto específico por ID.
 Crea un nuevo producto.
 
 **Headers Requeridos:**
+
 ```
 Authorization: Bearer <token>
 ```
 
 **Cuerpo de la Petición:**
+
 ```json
 {
-    "name": "Nuevo Producto",
-    "description": "Descripción del producto",
-    "price": 99.99,
-    "ingredients": ["ing1", "ing2"],
-    "category": "Comida",
-    "image": "url_imagen"
+  "name": "Nuevo Producto",
+  "description": "Descripción del producto",
+  "price": 99.99,
+  "ingredients": ["ing1", "ing2"],
+  "category": "Comida",
+  "image": "url_imagen"
 }
 ```
 
@@ -325,19 +414,22 @@ Authorization: Bearer <token>
 Modifica los detalles de un producto existente.
 
 **Headers Requeridos:**
+
 ```
 Authorization: Bearer <token>
 ```
 
 **Parámetros URL:**
+
 - id: ID del producto a modificar
 
 **Cuerpo de la Petición:**
+
 ```json
 {
-    "name": "Nombre Actualizado",
-    "description": "Nueva descripción",
-    "price": 109.99
+  "name": "Nombre Actualizado",
+  "description": "Nueva descripción",
+  "price": 109.99
 }
 ```
 
@@ -346,6 +438,7 @@ Authorization: Bearer <token>
 Alterna el estado de un producto.
 
 **Headers Requeridos:**
+
 ```
 Authorization: Bearer <token>
 ```
@@ -356,19 +449,21 @@ Authorization: Bearer <token>
 | id | number | ID del producto |
 
 **Respuesta Exitosa (200):**
+
 ```json
 {
-    "message": "Producto activado exitosamente",
-    "product": {
-        "idProduct": 1,
-        "name": "Producto Ejemplo",
-        "status": true,
-        // ... otros campos del producto
-    }
+  "message": "Producto activado exitosamente",
+  "product": {
+    "idProduct": 1,
+    "name": "Producto Ejemplo",
+    "status": true
+    // ... otros campos del producto
+  }
 }
 ```
 
 **Errores Posibles:**
+
 - 400: Producto no encontrado
 - 401: Token no proporcionado
 - 403: Usuario no es administrador
@@ -381,6 +476,7 @@ Authorization: Bearer <token>
 Actualiza o crea una personalización para un producto específico.
 
 **Headers Requeridos:**
+
 ```
 Authorization: Bearer <token>
 ```
@@ -391,37 +487,41 @@ Authorization: Bearer <token>
 | id | number | ID del producto |
 
 **Cuerpo de la Petición:**
+
 ```json
 {
-    "name": "Nombre de la personalización",
-    "status": true
+  "name": "Nombre de la personalización",
+  "status": true
 }
 ```
 
 **Validaciones:**
+
 - name: String no vacío
 - status: Boolean requerido
 
 **Respuesta Exitosa (200):**
+
 ```json
 {
-    "message": "Personalización actualizada exitosamente",
-    "personalization": {
-        "idPersonalization": 1,
-        "name": "Nombre de la personalización",
-        "status": true,
-        // ... otros campos
-    },
-    "productPersonalization": {
-        "idProductPersonalization": 1,
-        "idProduct": 1,
-        "idPersonalization": 1,
-        // ... otros campos
-    }
+  "message": "Personalización actualizada exitosamente",
+  "personalization": {
+    "idPersonalization": 1,
+    "name": "Nombre de la personalización",
+    "status": true
+    // ... otros campos
+  },
+  "productPersonalization": {
+    "idProductPersonalization": 1,
+    "idProduct": 1,
+    "idPersonalization": 1
+    // ... otros campos
+  }
 }
 ```
 
 **Errores Posibles:**
+
 - 400: Producto no encontrado
 - 400: Datos de personalización inválidos
 - 401: Token no proporcionado
@@ -435,6 +535,7 @@ Authorization: Bearer <token>
 Obtiene los detalles las personalizaciónes para un producto específico.
 
 **Headers Requeridos:**
+
 ```
 Authorization: Bearer <token>
 ```
@@ -444,8 +545,8 @@ Authorization: Bearer <token>
 |-----------|------|-------------|
 | id | number | ID del producto |
 
-
 **Respuesta Exitosa (200):**
+
 ```json
 {
   "message": "Personalizaciones obtenidas correctamente",
@@ -499,6 +600,7 @@ Authorization: Bearer <token>
 ```
 
 **Errores Posibles:**
+
 - 400: Producto no encontrado
 - 401: Token no proporcionado
 - 403: Usuario no es administrador
@@ -511,6 +613,7 @@ Authorization: Bearer <token>
 Cambia el estado de activo o inactivo de personalización para un producto específico.
 
 **Headers Requeridos:**
+
 ```
 Authorization: Bearer <token>
 ```
@@ -522,16 +625,19 @@ Authorization: Bearer <token>
 | idProductPersonalization | number | ID de la personalizacion del producto |
 
 **Cuerpo de la Petición:**
+
 ```json
 {
-    "status": true
+  "status": true
 }
 ```
 
 **Validaciones:**
+
 - status: Boolean requerido
 
 **Respuesta Exitosa (200):**
+
 ```json
 {
   "message": "Estado de personalización actualizado correctamente",
@@ -555,6 +661,7 @@ Authorization: Bearer <token>
 ```
 
 **Errores Posibles:**
+
 - 400: Producto no encontrado
 - 400: Datos de personalización inválidos
 - 401: Token no proporcionado
@@ -569,29 +676,34 @@ Para acceder a los endpoints de administrador, el usuario debe:
 2. Tener tipo de usuario administrador (idUserType === 1)
 
 **Respuesta de Error de Permisos (403):**
+
 ```json
 {
-    "message": "Acceso denegado. Se requieren permisos de administrador."
+  "message": "Acceso denegado. Se requieren permisos de administrador."
 }
 ```
 
 ### 8.6 Consideraciones Técnicas
 
 1. **Transacciones:**
+
    - Las operaciones de personalización utilizan transacciones Prisma
    - Si algo falla, se hace rollback automático
 
 2. **Validaciones:**
+
    - Se valida la existencia del producto
    - Se validan los datos de personalización
    - Se verifica el estado del producto
 
 3. **Seguridad:**
+
    - Todos los endpoints requieren autenticación
    - Se verifica el rol de administrador
    - Se registra el usuario que realiza los cambios
 
 4. **Respuestas:**
+
    - Códigos HTTP estándar
    - Mensajes descriptivos
    - Datos actualizados en la respuesta
@@ -599,7 +711,7 @@ Para acceder a los endpoints de administrador, el usuario debe:
 5. **Auditoría:**
    - Se registra quién realizó los cambios (idUserAdded)
    - Se mantiene historial de estados
-   - Timestamps automáticos 
+   - Timestamps automáticos
 
 ## 9. ENDPOINTS DE USUARIO
 
@@ -608,25 +720,29 @@ Para acceder a los endpoints de administrador, el usuario debe:
 **PUT /api/auth/email**
 
 **Headers Requeridos:**
+
 ```
 Authorization: Bearer <token>
 ```
 
 **Cuerpo de la Petición:**
+
 ```json
 {
-    "email": "nuevo@email.com"
+  "email": "nuevo@email.com"
 }
 ```
 
 **Respuesta Exitosa (200):**
+
 ```json
 {
-    "message": "Correo electrónico actualizado exitosamente"
+  "message": "Correo electrónico actualizado exitosamente"
 }
 ```
 
 **Errores Posibles:**
+
 - 400: Email inválido
 - 400: Email ya existe
 - 401: Token no proporcionado
@@ -639,38 +755,42 @@ Authorization: Bearer <token>
 **GET /admin/products**
 
 **Headers Requeridos:**
+
 ```
 Authorization: Bearer <token>
 ```
 
 **Parámetros de Query:**
+
 - page: Número de página (default: 1)
 - limit: Productos por página (fijo: 5)
 
 **Respuesta Exitosa (200):**
+
 ```json
 {
-    "message": "Productos obtenidos correctamente",
-    "data": {
-        "products": [
-            {
-                "idProduct": 1,
-                "name": "Hamburguesa Clásica",
-                "description": "Hamburguesa con carne, lechuga, tomate y queso",
-                "price": 89.99,
-                "status": true,
-                "productType": {
-                    "type": "Comida"
-                }
-            }
-        ],
-        "totalPages": 3,
-        "currentPage": 1
-    }
+  "message": "Productos obtenidos correctamente",
+  "data": {
+    "products": [
+      {
+        "idProduct": 1,
+        "name": "Hamburguesa Clásica",
+        "description": "Hamburguesa con carne, lechuga, tomate y queso",
+        "price": 89.99,
+        "status": true,
+        "productType": {
+          "type": "Comida"
+        }
+      }
+    ],
+    "totalPages": 3,
+    "currentPage": 1
+  }
 }
 ```
 
 **Errores Posibles:**
+
 - 401: Token no proporcionado
 - 403: Usuario no es administrador
 - 500: Error del servidor
@@ -680,37 +800,41 @@ Authorization: Bearer <token>
 **POST /admin/products**
 
 **Headers Requeridos:**
+
 ```
 Authorization: Bearer <token>
 ```
 
 **Cuerpo de la Petición:**
+
 ```json
 {
-    "idProductType": 1,
-    "name": "Nuevo Producto",
-    "description": "Descripción del producto",
-    "price": 99.99,
-    "status": true
+  "idProductType": 1,
+  "name": "Nuevo Producto",
+  "description": "Descripción del producto",
+  "price": 99.99,
+  "status": true
 }
 ```
 
 **Respuesta Exitosa (201):**
+
 ```json
 {
-    "message": "Producto agregado exitosamente",
-    "product": {
-        "idProduct": 1,
-        "name": "Nuevo Producto",
-        "description": "Descripción del producto",
-        "price": 99.99,
-        "status": true,
-        "idUserAdded": 1
-    }
+  "message": "Producto agregado exitosamente",
+  "product": {
+    "idProduct": 1,
+    "name": "Nuevo Producto",
+    "description": "Descripción del producto",
+    "price": 99.99,
+    "status": true,
+    "idUserAdded": 1
+  }
 }
 ```
 
 **Errores Posibles:**
+
 - 400: Datos de producto inválidos
 - 401: Token no proporcionado
 - 403: Usuario no es administrador
@@ -721,37 +845,42 @@ Authorization: Bearer <token>
 **PUT /admin/products/{id}**
 
 **Headers Requeridos:**
+
 ```
 Authorization: Bearer <token>
 ```
 
 **Parámetros URL:**
+
 - id: ID del producto a modificar
 
 **Cuerpo de la Petición:**
+
 ```json
 {
-    "name": "Nombre Actualizado",
-    "description": "Nueva descripción",
-    "price": 109.99
+  "name": "Nombre Actualizado",
+  "description": "Nueva descripción",
+  "price": 109.99
 }
 ```
 
 **Respuesta Exitosa (200):**
+
 ```json
 {
-    "message": "Detalles del producto actualizados correctamente",
-    "product": {
-        "idProduct": 1,
-        "name": "Nombre Actualizado",
-        "description": "Nueva descripción",
-        "price": 109.99,
-        "status": true
-    }
+  "message": "Detalles del producto actualizados correctamente",
+  "product": {
+    "idProduct": 1,
+    "name": "Nombre Actualizado",
+    "description": "Nueva descripción",
+    "price": 109.99,
+    "status": true
+  }
 }
 ```
 
 **Errores Posibles:**
+
 - 400: ID de producto inválido
 - 400: Datos de actualización inválidos
 - 401: Token no proporcionado
@@ -764,59 +893,58 @@ Authorization: Bearer <token>
 **GET /products**
 
 **Headers Requeridos:**
+
 ```
 Authorization: Bearer <token>
 ```
 
-
 **Respuesta Exitosa (200):**
-***Adminstrador***
+**_Adminstrador_**
 
 ```json
 {
-    "message": "Productos obtenidos correctamente",
-    "data": {
-        "products": [
-            {
-                "idProduct": 1,
-                "idProductType": 1,
-                "idUserAdded": 1,
-                "name": "Hamburguesa Clásica",
-                "description": "Hamburguesa con carne, lechuga, tomate y queso",
-                "price": 89.99,
-                "status": true,
-                "createdAt": "2025-03-08T02:01:04.163Z"
-            }
-        ]
-    }
+  "message": "Productos obtenidos correctamente",
+  "data": {
+    "products": [
+      {
+        "idProduct": 1,
+        "idProductType": 1,
+        "idUserAdded": 1,
+        "name": "Hamburguesa Clásica",
+        "description": "Hamburguesa con carne, lechuga, tomate y queso",
+        "price": 89.99,
+        "status": true,
+        "createdAt": "2025-03-08T02:01:04.163Z"
+      }
+    ]
+  }
 }
-
 ```
 
 **Respuesta Exitosa (200):**
-***Cliente***
+**_Cliente_**
 
 ```json
 {
-    "message": "Productos obtenidos correctamente",
-    "data": {
-        "products": [
-            {
-                "idProduct": 1,
-                "idProductType": 1,
-                "name": "Hamburguesa Clásica",
-                "description": "Hamburguesa con carne, lechuga, tomate y queso",
-                "price": 89.99,
-                "status": true,
-                "createdAt": "2025-03-08T02:01:04.163Z"
-            }
-        ]
-    }
+  "message": "Productos obtenidos correctamente",
+  "data": {
+    "products": [
+      {
+        "idProduct": 1,
+        "idProductType": 1,
+        "name": "Hamburguesa Clásica",
+        "description": "Hamburguesa con carne, lechuga, tomate y queso",
+        "price": 89.99,
+        "status": true,
+        "createdAt": "2025-03-08T02:01:04.163Z"
+      }
+    ]
+  }
 }
-
 ```
 
 **Errores Posibles:**
+
 - 401: Token no proporcionado
 - 404: No se encontraron productos
 - 500: Error del servidor
@@ -826,40 +954,42 @@ Authorization: Bearer <token>
 **PUT /cart/cart/items/{id}**
 
 **Headers Requeridos:**
+
 ```
 Authorization: Bearer <token>
 ```
 
 **Parámetros URL:**
+
 - id: ID del producto a agregar al carrito
 
 **Cuerpo de la Petición:**
+
 ```json
 {
-    "quantity": 3
+  "quantity": 3
 }
 ```
 
 **Respuesta Exitosa (201):**
 
-
 ```json
 {
-    "message": "Producto agregado al carrito",
-    "cartId": 1,
-    "item": {
-        "idItemCart": 2,
-        "idCart": 1,
-        "idProduct": 3,
-        "quantity": 2,
-        "individualPrice": 25,
-        "status": true
-    }
+  "message": "Producto agregado al carrito",
+  "cartId": 1,
+  "item": {
+    "idItemCart": 2,
+    "idCart": 1,
+    "idProduct": 3,
+    "quantity": 2,
+    "individualPrice": 25,
+    "status": true
+  }
 }
-
 ```
 
 **Errores Posibles:**
+
 - 401: Token no proporcionado
 - 400: Error de solicitud
 - 404: Producto no encontrado
@@ -870,31 +1000,34 @@ Authorization: Bearer <token>
 **PUT /cart/cart/items/{id}**
 
 **Headers Requeridos:**
+
 ```
 Authorization: Bearer <token>
 ```
 
 **Parámetros URL:**
+
 - id: ID del producto a modificar la cantidad en el carrito
 
 **Respuesta Exitosa (201):**
 
-
 ```json
 {
-    "message": "Cantidad del producto actualizada en el carrito",
-    "cartId": 2,
-    "item": {
-        "idItemCart": 4,
-        "idCart": 2,
-        "idProduct": 1,
-        "quantity": 3,
-        "individualPrice": 89,
-        "status": true
-    }
+  "message": "Cantidad del producto actualizada en el carrito",
+  "cartId": 2,
+  "item": {
+    "idItemCart": 4,
+    "idCart": 2,
+    "idProduct": 1,
+    "quantity": 3,
+    "individualPrice": 89,
+    "status": true
+  }
 }
 ```
+
 **Errores Posibles:**
+
 - 401: Token no proporcionado
 - 400: Error de solicitud
 - 404: Producto no encontrado
@@ -905,33 +1038,34 @@ Authorization: Bearer <token>
 **DELETE /cart/cart/items/{id}**
 
 **Headers Requeridos:**
+
 ```
 Authorization: Bearer <token>
 ```
 
 **Parámetros URL:**
+
 - id: ID del producto a eliminar en el carrito
 
 **Respuesta Exitosa (200):**
 
-
 ```json
-
 {
-    "message": "Producto eliminado del carrito",
-    "cartId": 1,
-    "item": {
-        "idItemCart": 1,
-        "idCart": 1,
-        "idProduct": 1,
-        "quantity": 3,
-        "individualPrice": 89,
-        "status": false
-    }
+  "message": "Producto eliminado del carrito",
+  "cartId": 1,
+  "item": {
+    "idItemCart": 1,
+    "idCart": 1,
+    "idProduct": 1,
+    "quantity": 3,
+    "individualPrice": 89,
+    "status": false
+  }
 }
 ```
 
 **Errores Posibles:**
+
 - 401: Token no proporcionado
 - 400: Error de peticion
 - 403: Esta producto ya ha sido desactivado en el carrito o este no existe en carrito.
@@ -942,42 +1076,43 @@ Authorization: Bearer <token>
 **GET /cart/**
 
 **Headers Requeridos:**
+
 ```
 Authorization: Bearer <token>
 ```
 
 **Respuesta Exitosa (200):**
 
-
 ```json
 {
-    "items": {
-        "cartId": 1,
-        "items": [
-            {
-                "idItemCart": 1,
-                "idCart": 1,
-                "idProduct": 1,
-                "quantity": 3,
-                "individualPrice": 89,
-                "status": true,
-                "product": {
-                    "idProduct": 1,
-                    "idProductType": 1,
-                    "idUserAdded": 1,
-                    "name": "Hamburguesa Clásica",
-                    "description": "Hamburguesa con carne, lechuga, tomate y queso",
-                    "price": 89.99,
-                    "status": true,
-                    "createdAt": "2025-03-10T04:58:13.074Z"
-                }
-            }
-        ]
-    }
+  "items": {
+    "cartId": 1,
+    "items": [
+      {
+        "idItemCart": 1,
+        "idCart": 1,
+        "idProduct": 1,
+        "quantity": 3,
+        "individualPrice": 89,
+        "status": true,
+        "product": {
+          "idProduct": 1,
+          "idProductType": 1,
+          "idUserAdded": 1,
+          "name": "Hamburguesa Clásica",
+          "description": "Hamburguesa con carne, lechuga, tomate y queso",
+          "price": 89.99,
+          "status": true,
+          "createdAt": "2025-03-10T04:58:13.074Z"
+        }
+      }
+    ]
+  }
 }
 ```
 
 **Errores Posibles:**
+
 - 401: Token no proporcionado
 - 400: Error de peticion
 - 500: Error del servidor
@@ -987,12 +1122,12 @@ Authorization: Bearer <token>
 **GET /cart/total**
 
 **Headers Requeridos:**
+
 ```
 Authorization: Bearer <token>
 ```
 
 **Respuesta Exitosa (200):**
-
 
 ```json
 {
@@ -1006,6 +1141,7 @@ Authorization: Bearer <token>
 ```
 
 **Errores Posibles:**
+
 - 401: Token no proporcionado
 - 400: Error de peticion
 - 500: Error del servidor
@@ -1022,9 +1158,11 @@ Obtiene la imagen de un producto específico.
 | id | number | ID del producto |
 
 **Respuesta Exitosa:**
+
 - Devuelve directamente el archivo de imagen
 
 **Errores Posibles:**
+
 - 400: ID de producto inválido
 - 404: Producto no encontrado
 - 404: Este producto no tiene una imagen
@@ -1038,6 +1176,7 @@ Obtiene la imagen de un producto específico.
 Sube una imagen para un producto específico.
 
 **Headers Requeridos:**
+
 ```
 Authorization: Bearer <token>
 Content-Type: multipart/form-data
@@ -1049,9 +1188,11 @@ Content-Type: multipart/form-data
 | id | number | ID del producto |
 
 **Cuerpo de la Petición:**
+
 - `productImage`: Archivo de imagen (jpeg, jpg, png, webp)
 
 **Ejemplo de uso con Postman:**
+
 1. Seleccionar método POST
 2. Ingresar la URL: `http://localhost:3000/api/admin/products/:id/image`
 3. En la pestaña "Headers":
@@ -1063,18 +1204,20 @@ Content-Type: multipart/form-data
    - Seleccionar el archivo de imagen
 
 **Respuesta Exitosa (200):**
+
 ```json
 {
-    "message": "Imagen subida correctamente",
-    "product": {
-        "idProduct": 1,
-        "name": "Nombre del Producto",
-        "imageUrl": "/uploads/products/product-1.jpg"
-    }
+  "message": "Imagen subida correctamente",
+  "product": {
+    "idProduct": 1,
+    "name": "Nombre del Producto",
+    "imageUrl": "/uploads/products/product-1.jpg"
+  }
 }
 ```
 
 **Errores Posibles:**
+
 - 400: ID de producto inválido
 - 400: No se ha subido ninguna imagen
 - 400: Campo de imagen incorrecto (debe ser 'productImage')
@@ -1092,6 +1235,7 @@ Content-Type: multipart/form-data
 Busca productos con filtros y paginación.
 
 **Headers Requeridos:**
+
 ```
 Authorization: Bearer <token>
 ```
@@ -1108,6 +1252,7 @@ Authorization: Bearer <token>
 | limit | number | Productos por página (default: 10) | ?limit=20 |
 
 **Ejemplos de uso:**
+
 ```
 /api/products/search?name=hamburguesa&type=Comida&minPrice=50&maxPrice=200
 /api/products/search?page=2&limit=20
@@ -1115,33 +1260,35 @@ Authorization: Bearer <token>
 ```
 
 **Respuesta Exitosa (200):**
+
 ```json
 {
-    "message": "Productos encontrados",
-    "data": {
-        "products": [
-            {
-                "idProduct": 1,
-                "name": "Hamburguesa Clásica",
-                "description": "Hamburguesa con carne, lechuga, tomate y queso",
-                "price": 89.99,
-                "status": true,
-                "productType": {
-                    "type": "Comida"
-                }
-            }
-        ],
-        "pagination": {
-            "totalItems": 50,
-            "totalPages": 5,
-            "currentPage": 1,
-            "itemsPerPage": 10
+  "message": "Productos encontrados",
+  "data": {
+    "products": [
+      {
+        "idProduct": 1,
+        "name": "Hamburguesa Clásica",
+        "description": "Hamburguesa con carne, lechuga, tomate y queso",
+        "price": 89.99,
+        "status": true,
+        "productType": {
+          "type": "Comida"
         }
+      }
+    ],
+    "pagination": {
+      "totalItems": 50,
+      "totalPages": 5,
+      "currentPage": 1,
+      "itemsPerPage": 10
     }
+  }
 }
 ```
 
 **Notas:**
+
 - Los usuarios no administradores solo verán productos activos (status = true)
 - Los administradores pueden ver todos los productos y filtrar por status
 - La búsqueda por nombre es insensible a mayúsculas/minúsculas
@@ -1150,6 +1297,7 @@ Authorization: Bearer <token>
 - El orden es alfabético por nombre
 
 **Errores Posibles:**
+
 - 400: Parámetros de filtro inválidos
 - 401: Token no proporcionado
 - 500: Error del servidor
@@ -1161,40 +1309,44 @@ Authorization: Bearer <token>
 Obtiene una lista de los productos más populares basados en la cantidad de veces que han sido agregados a carritos.
 
 **Parámetros de Query:**
-~~~
+
+```
 limit: Número de productos a retornar (default: 5)
-~~~
+```
 
 **Respuesta Exitosa (200):**
-~~~json
+
+```json
 {
-    "message": "Productos populares obtenidos correctamente",
-    "data": {
-        "products": [
-            {
-                "idProduct": 1,
-                "name": "Hamburguesa Clásica",
-                "description": "Hamburguesa con carne, lechuga y tomate",
-                "price": 120.00,
-                "status": true,
-                "productType": {
-                    "type": "Comida"
-                },
-                "popularity": 25
-            },
-            // ... más productos
-        ]
-    }
+  "message": "Productos populares obtenidos correctamente",
+  "data": {
+    "products": [
+      {
+        "idProduct": 1,
+        "name": "Hamburguesa Clásica",
+        "description": "Hamburguesa con carne, lechuga y tomate",
+        "price": 120.0,
+        "status": true,
+        "productType": {
+          "type": "Comida"
+        },
+        "popularity": 25
+      }
+      // ... más productos
+    ]
+  }
 }
-~~~
+```
 
 **Notas:**
+
 - Solo retorna productos activos (status = true)
 - El campo "popularity" indica cuántas veces el producto ha sido agregado a carritos
 - Los productos están ordenados por popularidad de mayor a menor
 - Se requiere autenticación
 
 **Errores Posibles:**
+
 - 401: Token no proporcionado
 - 500: Error del servidor
 
@@ -1203,14 +1355,17 @@ limit: Número de productos a retornar (default: 5)
 **GET /products/{id}**
 
 **Headers Requeridos:**
+
 ```
 Authorization: Bearer <token>
 ```
+
 **Parámetros URL:**
+
 - id: ID del producto a consultar
 
 **Respuesta Exitosa (200):**
-***Adminstrador***
+**_Adminstrador_**
 
 ```json
 {
@@ -1232,7 +1387,7 @@ Authorization: Bearer <token>
 ```
 
 **Respuesta Exitosa (200):**
-***Cliente***
+**_Cliente_**
 
 ```json
 {
@@ -1253,6 +1408,7 @@ Authorization: Bearer <token>
 ```
 
 **Errores Posibles:**
+
 - 401: Token no proporcionado
 - 404: No se encontro el producto
 - 500: Error del servidor
@@ -1260,15 +1416,17 @@ Authorization: Bearer <token>
 ## 11. ENDPOINTS DE DIRECCIONES
 
 ### 11.1 Agrega una nueva de dirrecion
+
 **POST /api/shipping-address**
 
 **Headers Requeridos:**
+
 ```
 Authorization: Bearer <token>
 ```
 
-
 **Cuerpo de la Petición:**
+
 ```json
 {
   "street": "Av. Luis Encinas Jhonson",
@@ -1279,7 +1437,6 @@ Authorization: Bearer <token>
 ```
 
 **Respuesta Exitosa (201):**
-
 
 ```json
 {
@@ -1294,26 +1451,26 @@ Authorization: Bearer <token>
     "status": true
   }
 }
-
 ```
 
 **Errores Posibles:**
+
 - 401: Token no proporcionado
 - 400: Error de solicitud
 - 404: Producto no encontrado
 - 500: Error del servidor
 
 ### 11.1 Obtener una direccion
+
 **GET /api/shipping-address**
 
 **Headers Requeridos:**
+
 ```
 Authorization: Bearer <token>
 ```
 
-
 **Respuesta Exitosa (200):**
-
 
 ```json
 {
@@ -1328,10 +1485,10 @@ Authorization: Bearer <token>
     "status": true
   }
 }
-
 ```
 
 **Errores Posibles:**
+
 - 401: Token no proporcionado
 - 400: No se encontró dirección activa para este usuario."
 - 500: Error del servidor
@@ -1339,6 +1496,7 @@ Authorization: Bearer <token>
 ## 12. VALIDACIONES DE PRODUCTOS
 
 ### 12.1 Creación de Producto
+
 - **idProductType**: Número entero positivo
 - **name**: Mínimo 3 caracteres
 - **description**: Mínimo 3 caracteres
@@ -1346,37 +1504,41 @@ Authorization: Bearer <token>
 - **status**: Booleano
 
 ### 12.2 Actualización de Detalles
+
 - **name**: (Opcional) Mínimo 3 caracteres
 - **description**: (Opcional) Mínimo 3 caracteres
 - Al menos uno de los campos debe estar presente
 
 ## 13. VALIDACIONES DE CARRITO
+
 ### 13.1 Añadir producto directamente al carrito
+
 - **idProduct**: Número entero positivo
 - **quantity**: Número entero positivo no superior a 100
 - Ambos campos son obligatorios
-
 
 ### 13.2 Actualización de Cantidad
+
 - **idProduct**: Número entero positivo
 - **quantity**: Número entero positivo no superior a 100
 - Ambos campos son obligatorios
-
-
 
 ## 14. NOTAS TÉCNICAS ADICIONALES
 
 ### 14.1 Paginación
+
 - Implementada en listado de productos
 - 5 productos por página
 - Incluye total de páginas y página actual
 
 ### 14.2 Validaciones
+
 - Uso de Zod para validación de datos
 - Manejo de errores específicos por campo
 - Transformación automática de tipos
 
 ### 14.3 Seguridad
+
 - Verificación de roles para endpoints administrativos
 - Validación de propiedad de recursos
-- Sanitización de datos de entrada 
+- Sanitización de datos de entrada

--- a/backend/src/controllers/auth.controller.js
+++ b/backend/src/controllers/auth.controller.js
@@ -2,8 +2,19 @@ const authService = require('../services/auth.service');
 
 async function register(req, res) {
     try {
+        const { email, password, username, name, lastName, secondLastName, phone } = req.body;
+        const idUserType = 2; // Para registro de usuarios clientes
+        const user = await authService.registerUserService(email, password, username, name, lastName, secondLastName, phone, idUserType);
+        res.status(201).json(user);
+    } catch (error) {
+        res.status(400).json({ message: error.message });
+    }
+}
+
+async function registerAdmin(req, res) {
+    try {
         const { email, password, username, name, lastName, secondLastName, phone, idUserType } = req.body;
-        const user = await authService.registerUser(email, password, username, name, lastName, secondLastName, phone/*, idUserType*/);
+        const user = await authService.registerUserService(email, password, username, name, lastName, secondLastName, phone, idUserType);
         res.status(201).json(user);
     } catch (error) {
         res.status(400).json({ message: error.message });
@@ -92,6 +103,7 @@ async function updateEmail(req, res) {
 
 module.exports = {
     register,
+    registerAdmin,
     login,
     deleteProfile,
     updatePassword,

--- a/backend/src/routes/admin.routes.js
+++ b/backend/src/routes/admin.routes.js
@@ -5,6 +5,8 @@ const { isAdmin } = require('../middlewares/admin.middleware');
 const { getProduct, addProduct, modifyProductDetails, getAllProductsPagination } = require('../controllers/product.controller');
 const { toggleProductStatus, updateProductCustomization, uploadProductImage } = require('../controllers/admin.controller');
 const { handleProductImageUpload } = require('../middlewares/upload.middleware');
+const { validateRegister } = require('../middlewares/validateInput');
+const { registerAdmin } = require('../controllers/auth.controller');
 const adminController = require('../controllers/admin.controller');
 
 // Apply authentication middleware to all admin routes
@@ -17,6 +19,9 @@ router.post('/products', isAdmin, addProduct);
 router.put('/products/:id', isAdmin, modifyProductDetails);
 router.patch('/products/:id/status', isAdmin, toggleProductStatus);
 router.put('/products/:id/customization', isAdmin, updateProductCustomization);
+
+// Admin user routes
+router.post('/register', isAdmin, validateRegister, registerAdmin);
 
 // New route for uploading product images
 router.post('/products/:id/image', isAdmin, handleProductImageUpload, uploadProductImage);

--- a/backend/src/services/auth.service.js
+++ b/backend/src/services/auth.service.js
@@ -7,18 +7,8 @@ const { JWT_SECRET, JWT_EXPIRES_IN } = require('../config/jwt.config');
 const prisma = new PrismaClient();
 const SALT_ROUNDS = 10;
 
-async function registerUser(email, password, username, name, lastName, secondLastName, phone, /*idUserType*/) {
+async function registerUserService(email, password, username, name, lastName, secondLastName, phone, idUserType) {
     return await prisma.$transaction(async (tx) => {
-
-        //cambiar findUnique por findFirst
-        // const existingEmail = await tx.user.findUnique({
-        //     where: {
-        //         email: email,
-        //     },
-        // });
-        // if (existingEmail) {
-        //     throw new Error('Email ya existente');
-        // }
 
         const existingEmail = await tx.user.findFirst({
             where: {
@@ -48,7 +38,7 @@ async function registerUser(email, password, username, name, lastName, secondLas
                 password: password,
                 username: username,
                 status: true,
-                idUserType: 1,//De momento solo registra usuarios adminstradores, una vez se implemente el sistema de roles y JWT se cambiara
+                idUserType: idUserType,//Para registro de usuarios clientes
             },
         });
 
@@ -250,7 +240,7 @@ async function updateEmail(userId, email) {
 }
 
 module.exports = {
-    registerUser,
+    registerUserService,
     loginUser,
     deleteUserProfile,
     updatePassword,


### PR DESCRIPTION
# 🔹 ENDPOINT: Registro de nuevos admiradores.
### Fue añadió el **endpoint**: 
```
POST: /api/admin/register
```

- Permite que un administrador con sesión activa registre tanto administradores como clientes.
- En el cuerpo de la petición, se debe enviar el campo `idUserType`:
	- `1` → Para registrar administradores.
	- `2` → Para registrar clientes.

### Se modificó el **endpoint**: 
```
POST: /api/auth/register
```

- Ahora solo registra usuarios de tipo cliente.
- El campo idUserType se omite, y por defecto se asigna el valor 2 (cliente)
	
## Archivos Modificados
- `backend/src/controllers/auth.controller.js` → Se agregó la lógica para manejar los registros diferenciados.
- `backend/src/routes/admin.routes.js` → Se añadió la ruta para POST /api/admin/register.
- `backend/src/services/auth.service.js` → Se actualizó la lógica de registro según el tipo de usuario.

## Notas:
- Se actualizó la documentación en API.md para reflejar estos cambios.