### PR TITLE
Propuesta de encriptación para contraseñas

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,6 +4,10 @@
 # Prisma supports the native connection string format for PostgreSQL, MySQL, SQLite, SQL Server, MongoDB and CockroachDB.
 # See the documentation for all the connection string options: https://pris.ly/d/connection-strings
 
+# USE_PASSWORD_ENCRYPTION must be set to true in production.  
+# For development, use false.
+
+USE_PASSWORD_ENCRYPTION=false
 DATABASE_URL="mysql://user:user_password@mysql:3306/eddys-tender-db"
 JWT_SECRET=ywKwuDz+WKrLzDsqkUPMWLmucJ2fVH8qosU7jSQIRho=
 ENCRYPTION_KEY=d25/aIvJSekRl2Jft6ksXfVyPEt7ng2h9ANP+HcZAxc=

--- a/backend/package.json
+++ b/backend/package.json
@@ -23,14 +23,15 @@
   "dependencies": {
     "@prisma/client": "^6.3.1",
     "bcrypt": "^5.1.1",
+    "bcryptjs": "^3.0.2",
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
     "express-rate-limit": "^7.5.0",
     "jsonwebtoken": "^9.0.2",
+    "multer": "^1.4.5-lts.1",
     "nodemon": "^3.1.9",
-    "zod": "^3.24.2",
-    "multer": "^1.4.5-lts.1"
+    "zod": "^3.24.2"
   },
   "devDependencies": {
     "prettier": "3.4.2",

--- a/backend/src/config/bcrypt.config.js
+++ b/backend/src/config/bcrypt.config.js
@@ -1,0 +1,35 @@
+const bcrypt = require("bcryptjs");
+
+const shouldEncrypt = process.env.USE_PASSWORD_ENCRYPTION === "true";
+const saltRounds = 10;
+
+// Función para encriptar la contraseña
+async function hashPassword(password) {
+
+    if (!shouldEncrypt) {
+        return password; // En desarrollo, devuelve la contraseña sin encriptar
+    }
+    return await bcrypt.hash(password, saltRounds);
+}
+
+// Función para comparar contraseñas
+async function comparePassword(inputPassword, storedPassword) {
+
+    const isStoredHashed = storedPassword.length === 60 && storedPassword.startsWith("$2");
+
+    // Si la encriptación está deshabilitada, compara sin bcrypt
+    if (!shouldEncrypt) {
+        return inputPassword === storedPassword;
+    }
+
+    // Si la encriptación está activada y la contraseña almacenada está hasheada, usar bcrypt
+    if (isStoredHashed) {
+        return await bcrypt.compare(inputPassword, storedPassword);
+    }
+
+    // Si la encriptación está activada pero la contraseña almacenada NO está hasheada, compara directo
+    return inputPassword === storedPassword;
+}
+
+
+module.exports = { hashPassword, comparePassword }


### PR DESCRIPTION
## Resumen
Se creó bcrypt.config.js para gestionar el uso de bcryptjs, reemplazando la versión nativa de bcrypt para mejorar compatibilidad y estabilidad en distintos entornos de despliegue. Ahora, la encriptación de contraseñas puede habilitarse o deshabilitarse mediante la variable de entorno USE_PASSWORD_ENCRYPTION, facilitando la configuración y evitando errores en los endpoints relacionados.

## Cambios Clave

- Gestión flexible de encriptación mediante **`.env`** **`USE_PASSWORD_ENCRYPTION=true/false`**.

- Comparación de contraseñas:
  - Si la encriptación está activada, las contraseñas hasheadas se validan con bcrypt.
  - Para usuarios antiguos (contraseñas no encriptadas), se realiza una comparación directa (**esto puede ser cambiado**, fue dejado de esta manera para que el usuario administrador puede ser utilizado sin problemas).
  - Endpoints afectados: register, login, updatePassword.

## Configuración:
Para activar/desactivar la encriptación, modificar `.env`:

```
USE_PASSWORD_ENCRYPTION=true  # o false
```