### PR TITLE
Enpoint para reodenar pedidos agregado

### DIFF
--- a/backend/docs/API.md
+++ b/backend/docs/API.md
@@ -2656,7 +2656,55 @@ limit: Resultados por página (default: 10)
 - 401: Token no proporcionado
 - 500: Error del servidor
 
-### 14.5 Webhook de Stripe
+## 14.5 Reodernar pedido
+**PUT /api/orders/:idOrder**
+
+Permite agregar productos de una orden ya existente al carrito de compras.
+
+**Encabezados Requeridos:**
+
+```
+Authorization: Bearer <token>
+```
+**Parámetros URL:**
+
+- idOrder: ID de pedido existente a reodenar
+
+**Respuesta Exitosa (200):**
+
+```json
+{
+    "message": "Pedido reordenado correctamente, productos agregados al carrito",
+    "data": {
+        "cartId": 2,
+        "items": [
+            {
+                "idProduct": 2,
+                "quantity": 3,
+                "individualPrice": 149.99,
+                "status": true,
+                "idCart": 2
+            }
+        ]
+    }
+}
+
+```
+**Notas:**
+
+- Los productos existentes en el carrito de compras activo, son reemplados por los de los del pedido a reordenar.
+- Se valida que si lo productos a reordenar son los mismos a los ya existentes el carrito de compras, no se efectuen cambios.
+
+**Errores Posibles:**
+
+- 401: Token no proporcionado
+- 400: ID inválido
+- 403: Orden no encontrada o sin permiso para eliminar
+- 409: El carrito ya contiene los mismos productos
+- 500: Error del servidor
+
+
+### 14.6 Webhook de Stripe
 
 **POST /api/webhooks/stripe**
 

--- a/backend/src/controllers/order.controller.js
+++ b/backend/src/controllers/order.controller.js
@@ -212,12 +212,50 @@ async function getOrderHistory(req, res) {
     }
 }
 
-module.exports = {
-    getActiveOrders,
-    getOrderHistory
-};
+async function reoder(req, res) {
+    try {
+        const orderId = parseInt(req.params.orderId);
+        const userId = req.user.userId;
+
+        const result = await orderService.reorderService(userId, orderId);
+
+        return res.status(200).json({
+            message: "Pedido reordenado correctamente, productos agregados al carrito",
+            data: result
+        });
+    } catch (error) {
+        console.error("Error al reordenar:", error);
+        // Custom error handling
+        let message;
+        let status = 400;
+        switch (error.message) {
+            case 'Orden no encontrada':
+                status = 404;
+                message = 'El pedido no existe';
+                break;
+            case 'Ninguno de los productos de la orden esta disponible actualmente':
+                status = 404;
+                message = 'Ninungo de los productos de la orden se encuentran disponible actualmente';
+                break;
+            case 'La orden no pertenece al usuario':
+                status = 403;
+                message = 'No tienes permiso para reordenar este pedido, solo puedes reordenar tus propios pedidos';
+                break;
+            case 'El carrito ya contiene los mismos productos':
+                status = 409;
+                message = 'El carrito ya contiene los mismos productos';
+                break;
+            default:
+                message = 'Error al reordenar el pedido';
+        }
+        return res.status(status).json({ message });
+    }
+}
 
 module.exports = {
+    getActiveOrders,
+    getOrderHistory,
+    reoder,
     createOrder,
     getOrderDetails,
     getUserOrders,

--- a/backend/src/routes/order.routes.js
+++ b/backend/src/routes/order.routes.js
@@ -5,7 +5,8 @@ const {
     createOrder,
     getOrderDetails,
     getUserOrders,
-    searchOrders
+    searchOrders,
+    reoder
 } = require('../controllers/order.controller');
 
 // Apply authentication to all order routes
@@ -22,5 +23,8 @@ router.get('/', getUserOrders);
 
 // Get a specific order's details
 router.get('/:id', getOrderDetails);
+
+// Reorder a previous order
+router.put('/:orderId', reoder);
 
 module.exports = router; 


### PR DESCRIPTION
# Endpoint para reordenar pedido
Permite reordenar productos desde un pedido anterior, agregándolos al carrito activo del usuario autenticado.

`PUT` 
```
/api/orders/:idOrder
```

- Obtiene los productos y cantidades del pedido original.

- Verifica que los productos estén activos en la tabla Product.

- Revisa si el usuario ya tiene un carrito activo:

  - Si el carrito contiene exactamente los mismos productos y cantidades, no se realiza ningún cambio.
 
  - Si los productos difieren, el carrito actual se desactiva y se crea uno nuevo con los productos del pedido.

## Notas:
- Si el carrito ya contiene exactamente los mismos productos y cantidades, no se realiza ningún cambio.

- Si alguno de los productos del pedido está inactivo ( `status = false ` en `Product` ), será omitido.

  - Si ningún producto activo está disponible para reordenar, se lanza una excepción personalizada.