### PR TITLE
Incluir customizaciones inactivas admin

### DIFF
--- a/backend/src/controllers/product.controller.js
+++ b/backend/src/controllers/product.controller.js
@@ -158,7 +158,6 @@ async function getProductPersonalizations(req, res) {
         const personalizations = await prisma.productPersonalization.findMany({
             where: {
                 idProduct: productId,
-                status: true
             },
             include: {
                 personalization: true
@@ -291,7 +290,7 @@ async function updateProductPersonalizationForUser(req, res) {
 
 
         res.json({
-            message: "Personalización actualizada exitosamente",
+            message: "Personalizacion actualizada exitosamente",
             data: {
                 Personalization,
                 ProductPersonalization


### PR DESCRIPTION
- Ahora se incluyen todas la customizaciones de usuario para un producto para **administradores**.

- Posibilita el cambio de status en frontend

- El `status` de la customización es incluido en la respuesta.