### PR TITLE
Cambios en el servicio para reordenar

### DIFF
--- a/backend/src/controllers/order.controller.js
+++ b/backend/src/controllers/order.controller.js
@@ -20,7 +20,7 @@ async function createOrder(req, res) {
                 message: 'Se requiere una dirección de entrega para envíos a domicilio'
             });
         }
-        
+
         // Validate shipment value if provided
         if (shipmentValue !== undefined) {
             const shipmentValueNumber = parseFloat(shipmentValue);
@@ -252,9 +252,9 @@ async function reoder(req, res) {
                 status = 403;
                 message = 'No tienes permiso para reordenar este pedido, solo puedes reordenar tus propios pedidos';
                 break;
-            case 'El carrito ya contiene los mismos productos':
-                status = 409;
-                message = 'El carrito ya contiene los mismos productos';
+            case 'No hay productos válidos con cantidad mayor a cero en la orden':
+                status = 403;
+                message = 'No hay productos válidos con cantidad mayor a cero en la orden';
                 break;
             default:
                 message = 'Error al reordenar el pedido';

--- a/backend/src/services/cart.service.js
+++ b/backend/src/services/cart.service.js
@@ -249,7 +249,7 @@ const getTotalAmountCartService = async (userId) => {
 
         // Calcular el total del carrito
         const totalAmount = items.reduce((total, item) => {
-            return total + (item.quantity * item.individualPrice);
+            return total + (item.quantity * item.product.price);
         }, 0);
 
         return { cartId: cart.idCart, totalAmount };


### PR DESCRIPTION
### Cambios en validación para reordenar un producto

- Ahora ya no es validado si existen exactamente lo mismo producto en el carrito
- Se valida que la orden anterior cuente por lo menos con 1 producto activo y su cantidad sea mayor a 0

## Notas:
- Ahora el endpoint para obtener el total del carrito respeta decimales.