### PR TITLE
Se agrega nombre de personlizacion en la respuesta a get personalization for cart item

### DIFF
--- a/backend/docs/API.md
+++ b/backend/docs/API.md
@@ -2304,22 +2304,27 @@ Authorization: Bearer <token>
         {
             "idUserProductPersonalize": 1,
             "idItemCart": 1,
-            "idProductPersonalization": 1,
+            "idProductPersonalization": 5,
             "status": true,
             "productPersonalization": {
-                "idProductPersonalization": 1,
+                "idProductPersonalization": 5,
                 "idUserAdded": 1,
-                "idProduct": 1,
-                "idPersonalization": 1,
-                "status": true
+                "idProduct": 2,
+                "idPersonalization": 2,
+                "status": true,
+                "personalization": {
+                    "idPersonalization": 2,
+                    "name": "Extra Queso",
+                    "status": true
+                }
             },
             "itemCart": {
                 "idItemCart": 1,
                 "idCart": 1,
-                "idProduct": 1,
-                "quantity": 0,
-                "individualPrice": 89,
-                "status": false
+                "idProduct": 2,
+                "quantity": 1,
+                "individualPrice": 149,
+                "status": true
             }
         }
     ]

--- a/backend/src/controllers/product.controller.js
+++ b/backend/src/controllers/product.controller.js
@@ -407,15 +407,32 @@ async function getPersonalizationsForCartItem(req, res) {
                 idItemCart,
             },
             include: {
-                productPersonalization: true,
+                productPersonalization: {
+                    include: {
+                        personalization: true,
+                    },
+                },
                 itemCart: true,
             },
         });
 
+        const sanitized = personalizations.map(p => ({
+            ...p,
+            productPersonalization: {
+                ...p.productPersonalization,
+                personalization: {
+                    idPersonalization: p.productPersonalization.personalization.idPersonalization,
+                    name: p.productPersonalization.personalization.name,
+                    status: p.productPersonalization.personalization.status,
+                },
+            },
+        }));
+
         res.json({
             message: "Personalizaciones recuperadas correctamente",
-            data: personalizations,
+            data: sanitized,
         });
+
     } catch (error) {
         console.error("Error al recuperar personalizaciones:", error);
         res.status(500).json({ message: "Error interno", error: error.message });


### PR DESCRIPTION
## Se ajusto el endpoint:
`GET`

```
/api/cart/items/personalizations/:idItemCart
```

Ahora, la respuesta incluye el nombre, estado e identificador de la personalización `(personalization.name`,` status`, `idPersonalization`).